### PR TITLE
Update kube api resources

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -1,30 +1,42 @@
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: vpa-admission-controller
   name: vpa-admission-controller
   namespace: kube-system
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: vpa-admission-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: vpa-admission-controller
     spec:
-      serviceAccountName: vpa-admission-controller
       containers:
-      - name: admission-controller
-        image: k8s.gcr.io/vpa-admission-controller:0.4.0
-        imagePullPolicy: Always
-        env:
+      - env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:
+              apiVersion: v1
               fieldPath: metadata.namespace
-        volumeMounts:
-          - name: tls-certs
-            mountPath: "/etc/tls-certs"
-            readOnly: true
+        image: k8s.gcr.io/vpa-admission-controller:0.4.0
+        imagePullPolicy: Always
+        name: admission-controller
+        ports:
+        - containerPort: 8000
+          protocol: TCP
         resources:
           limits:
             cpu: 200m
@@ -32,12 +44,25 @@ spec:
           requests:
             cpu: 50m
             memory: 200Mi
-        ports:
-        - containerPort: 8000
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/tls-certs
+          name: tls-certs
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: vpa-admission-controller
+      serviceAccountName: vpa-admission-controller
+      terminationGracePeriodSeconds: 30
       volumes:
-        - name: tls-certs
-          secret:
-            secretName: vpa-tls-certs
+      - name: tls-certs
+        secret:
+          defaultMode: 420
+          secretName: vpa-tls-certs
+status: {}
 ---
 apiVersion: v1
 kind: Service

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -4,24 +4,39 @@ kind: ServiceAccount
 metadata:
   name: vpa-recommender
   namespace: kube-system
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: vpa-recommender
   name: vpa-recommender
   namespace: kube-system
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: vpa-recommender
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: vpa-recommender
     spec:
-      serviceAccountName: vpa-recommender
       containers:
-      - name: recommender
-        image: k8s.gcr.io/vpa-recommender:0.4.0
+      - image: k8s.gcr.io/vpa-recommender:0.4.0
         imagePullPolicy: Always
+        name: recommender
+        ports:
+        - containerPort: 8080
+          protocol: TCP
         resources:
           limits:
             cpu: 200m
@@ -29,5 +44,13 @@ spec:
           requests:
             cpu: 50m
             memory: 500Mi
-        ports:
-        - containerPort: 8080
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: vpa-recommender
+      serviceAccountName: vpa-recommender
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -4,24 +4,39 @@ kind: ServiceAccount
 metadata:
   name: vpa-updater
   namespace: kube-system
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: vpa-updater
   name: vpa-updater
   namespace: kube-system
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: vpa-updater
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: vpa-updater
     spec:
-      serviceAccountName: vpa-updater
       containers:
-      - name: updater
-        image: k8s.gcr.io/vpa-updater:0.4.0
+      - image: k8s.gcr.io/vpa-updater:0.4.0
         imagePullPolicy: Always
+        name: updater
+        ports:
+        - containerPort: 8080
+          protocol: TCP
         resources:
           limits:
             cpu: 200m
@@ -29,5 +44,13 @@ spec:
           requests:
             cpu: 50m
             memory: 500Mi
-        ports:
-        - containerPort: 8080
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: vpa-updater
+      serviceAccountName: vpa-updater
+      terminationGracePeriodSeconds: 30
+status: {}


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team